### PR TITLE
removing route from engine and adding it to the generator

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,0 @@
-Rails.application.routes.draw do
-  get 'progress-job/:job_id' => 'progress_job/progress#show'
-end

--- a/lib/generators/progress_job/install_generator.rb
+++ b/lib/generators/progress_job/install_generator.rb
@@ -10,6 +10,7 @@ module ProgressJob
 
       def install
         migration_template "migration.rb", "db/migrate/add_progress_to_delayed_jobs.rb"
+        route "get 'progress-job/:job_id' => 'progress_job/progress#show'"
       end
 
       def self.next_migration_number(path)


### PR DESCRIPTION
Thanks for the very cool gem!  This is very useful.

I'm not very fluent with creating engines, but it seems that the route created when using your engine approach is added to the very end of the list of all routes.  This can be a problem because many application use route globbing at the bottom of the routes.rb file to capture erroneous routes.  Like this example:  `match '*path', via: [:get, :post], to: 'application#routing_error'`

The route added from your engine appears below this route and thus is never reached.  I've seen other engines that use the generator to write directly into the main application's routes.rb file.  This PR is taking that approach.   

I believe if you want to add a route using your engine and not have it at the end of your application's routes.rb file, you can try this approach with an isolated_namespace:

http://edgeguides.rubyonrails.org/engines.html#routes

I personally like the generator approach better.  Less magic :)  
