### PR TITLE
Job not found json response

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ There is also a controller which returns the delayed job with calculated percent
   end
 ```
 
-### HAML 
+### HAML
 
 ``` ruby
   = simple_form_for :import, url: [:import], remote: true do |f|
@@ -133,22 +133,32 @@ Example of ajax call (this is a .html.haml remote: true response):
   $('.hermes-import .well').show();
   interval = setInterval(function(){
     $.ajax({
-      url: '/progress-job/' + #{@job.id},
-      success: function(job){
+      url: '/progress-job/' + #{@job.id}
+    })
+    .done(function(data){
+
+      // Job is no longer in database which means it finished successfully
+      if(data.job_not_found){
+        $('.progress').removeClass('active');
+        $('.progress-bar').css('width', '100%').text('100%');
+        $('.progress-status').text('Successfully imported!');
+        clearInterval(interval);
+      }
+      else {
         var stage, progress;
 
         // If there are errors
-        if (job.last_error != null) {
-          $('.progress-status').addClass('text-danger').text(job.progress_stage);
+        if (data.last_error != null) {
+          $('.progress-status').addClass('text-danger').text(data.progress_stage);
           $('.progress-bar').addClass('progress-bar-danger');
           $('.progress').removeClass('active');
           clearInterval(interval);
         }
 
         // Upload stage
-        if (job.progress_stage != null){
-          stage = job.progress_stage;
-          progress = job.progress_current / job.progress_max * 100;
+        if (data.progress_stage != null){
+          stage = data.progress_stage;
+          progress = data.progress_current / data.progress_max * 100;
         } else {
           progress = 0;
           stage = 'Uploading file';
@@ -158,15 +168,7 @@ Example of ajax call (this is a .html.haml remote: true response):
         if (progress !== 0){
           $('.progress-bar').css('width', progress + '%').text(progress + '%');
         }
-
         $('.progress-status').text(stage);
-      },
-      error: function(){
-        // Job is no loger in database which means it finished successfuly
-        $('.progress').removeClass('active');
-        $('.progress-bar').css('width', '100%').text('100%');
-        $('.progress-status').text('Successfully imported!');
-        clearInterval(interval);
       }
     })
   },100);

--- a/app/controllers/progress_job/progress_controller.rb
+++ b/app/controllers/progress_job/progress_controller.rb
@@ -2,9 +2,13 @@ module ProgressJob
   class ProgressController < ActionController::Base
 
     def show
-      @delayed_job = Delayed::Job.find(params[:job_id])
-      percentage = !@delayed_job.progress_max.zero? ? @delayed_job.progress_current / @delayed_job.progress_max.to_f * 100 : 0
-      render json: @delayed_job.attributes.merge!(percentage: percentage).to_json
+      @delayed_job = Delayed::Job.find_by(id: params[:job_id])
+      if @delayed_job
+        percentage = !@delayed_job.progress_max.zero? ? @delayed_job.progress_current / @delayed_job.progress_max.to_f * 100 : 0
+        render json: @delayed_job.attributes.merge!(percentage: percentage).to_json
+      else
+        render json: {job_not_found: true}.to_json
+      end
     end
 
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,0 @@
-Rails.application.routes.draw do
-  get 'progress-job/:job_id' => 'progress_job/progress#show'
-end

--- a/lib/generators/progress_job/install_generator.rb
+++ b/lib/generators/progress_job/install_generator.rb
@@ -10,6 +10,7 @@ module ProgressJob
 
       def install
         migration_template "migration.rb", "db/migrate/add_progress_to_delayed_jobs.rb"
+        route "get 'progress-job/:job_id' => 'progress_job/progress#show'"
       end
 
       def self.next_migration_number(path)


### PR DESCRIPTION
Hi again!  I also ran into a few issues with relying on the jQuery ajax() error callback.  That can be triggered by a number of errors (HTTP errors for example).  I think it's more reliable to return explicit information in the JSON response about the record not being found, rather than relying on the error callback.

I updated the README in this PR to reflect that approach.

I also realize since this changes some core behavior, you may want to wait to put this into a larger version update.
