### PR TITLE
Fix for record not found

### DIFF
--- a/app/controllers/progress_job/progress_controller.rb
+++ b/app/controllers/progress_job/progress_controller.rb
@@ -3,9 +3,10 @@ module ProgressJob
 
     def show
       @delayed_job = Delayed::Job.find(params[:job_id])
-      return unless @delayed_job.present?
       percentage = !@delayed_job.progress_max.zero? ? @delayed_job.progress_current / @delayed_job.progress_max.to_f * 100 : 0
       render json: @delayed_job.attributes.merge!(percentage: percentage).to_json
+    rescue
+      @delayed_job = {}
     end
 
   end


### PR DESCRIPTION
Still getting this error:
ActiveRecord::RecordNotFound (Couldn't find Delayed::Backend::ActiveRecord::Job with 'id'...):
Suggestion:
The error should be rescued instead. The previous guard approach wouldn't catch this error.